### PR TITLE
feat: Set mark and Kill region

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,29 @@ Obsidian https://obsidian.md
 
 ## Usage
 
-### Kill
+### Kill line
 
 Cut from the cursor position to the end of the line.
 
 default: `Control + k`
+
+### Kill region
+
+Cut the selection.
+
+default: `Control + w`
 
 ### Yank
 
 Paste kill ring.
 
 default: `Control + y`
+
+### Set mark
+
+Toggle the start position of the selection.
+
+default: `Control + Space`
 
 ## Note
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,14 @@
 import { Editor, EditorPosition, MarkdownView, Plugin } from 'obsidian'
 
 export default class KillAndYankPlugin extends Plugin {
+  private editor: Editor
   private killRing: string
+  private mark: EditorPosition | null = null
 
   async onload() {
     this.addCommand({
-      id: 'kill',
-      name: 'Kill (Cut from the cursor position to the end of the line)',
+      id: 'kill-line',
+      name: 'Kill line (Cut from the cursor position to the end of the line)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'k' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
         const position: EditorPosition = editor.getCursor()
@@ -23,11 +25,35 @@ export default class KillAndYankPlugin extends Plugin {
     })
 
     this.addCommand({
+      id: 'kill-region',
+      name: 'Kill region (Cut the selection)',
+      hotkeys: [{ modifiers: ['Ctrl'], key: 'w' }],
+      editorCallback: (editor: Editor, view: MarkdownView) => {
+        this.killRing = editor.getSelection()
+        editor.replaceSelection('')
+      },
+    })
+
+    this.addCommand({
       id: 'yank',
       name: 'Yank (Paste)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'y' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
         editor.replaceSelection(this.killRing)
+      },
+    })
+
+    this.addCommand({
+      id: 'set-mark',
+      name: 'Set mark (Toggle the start position of the selection)',
+      hotkeys: [{ modifiers: ['Ctrl'], key: ' ' }],
+      editorCallback: (editor: Editor, view: MarkdownView) => {
+        if (this.mark) {
+          editor.setSelection(this.mark, editor.getCursor())
+          this.mark = null
+          return
+        }
+        this.mark = editor.getCursor()
       },
     })
   }


### PR DESCRIPTION
Reverts inouetakuya/obsidian-kill-and-yank#9

https://forum.obsidian.md/t/emacs-bindings-in-the-editor/734/11

> Another +1 for Emacs keybindings. Two things missing that are definitely hindering use:
> 
> One is Emacs ctl-K and ctl-Y (Kill & Yank), essentially “Cut current line & Paste”. In Obsidian, ctl-K correctly deletes the rest of the current line, but does not save the cut text so can be pasted with ctl-Y. In Bear, these two keys work great.
> 
> Other is being able to use Ctl-space to “set the Mark”, in order to select a region of text.

