### PR TITLE
add two features

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "prettier": "^2.8.3",
     "tslib": "2.4.0",
     "typescript": "4.7.4"
+  },
+  "dependencies": {
+    "codemirror": "^6.0.1"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Editor, EditorPosition, MarkdownView, Plugin } from 'obsidian'
+import { EditorView } from '@codemirror/view'
 
 export default class KillAndYankPlugin extends Plugin {
   private editor: Editor
@@ -11,16 +12,21 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Kill line (Cut from the cursor position to the end of the line)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'k' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        const position: EditorPosition = editor.getCursor()
-        const line: string = editor.getLine(position.line)
+        // @ts-expect-error
+        const editorView = view.editor.cm as EditorView
 
-        const textToBeRetained = line.slice(0, position.ch)
-        const textToBeCut = line.slice(position.ch)
+        if (!editorView.composing) {
+          const position: EditorPosition = editor.getCursor()
+          const line: string = editor.getLine(position.line)
 
-        this.killRing = textToBeCut
+          const textToBeRetained = line.slice(0, position.ch)
+          const textToBeCut = line.slice(position.ch)
 
-        editor.setLine(position.line, textToBeRetained)
-        editor.setCursor(position, position.ch)
+          this.killRing = textToBeCut
+
+          editor.setLine(position.line, textToBeRetained)
+          editor.setCursor(position, position.ch)
+        }
       },
     })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,6 @@ export default class KillAndYankPlugin extends Plugin {
       editorCallback: (editor: Editor, view: MarkdownView) => {
         // @ts-expect-error
         const editorView = view.editor.cm as EditorView
-
         if (!editorView.composing) {
           const position: EditorPosition = editor.getCursor()
           const line: string = editor.getLine(position.line)
@@ -49,7 +48,11 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Yank (Paste)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'y' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        editor.replaceSelection(this.killRing)
+        // @ts-expect-error
+        const editorView = view.editor.cm as EditorView
+        if (!editorView.composing) {
+          editor.replaceSelection(this.killRing)
+        }
       },
     })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ export default class KillAndYankPlugin extends Plugin {
       editorCallback: (editor: Editor, view: MarkdownView) => {
         if (this.isComposing(view)) return
         this.isMark(editor);
+        this.mark = null;
         this.killRing = editor.getSelection()
         editor.replaceSelection('')
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,14 @@ export default class KillAndYankPlugin extends Plugin {
     return editorView.composing
   }
 
+  private isMark(editor: Editor) {
+    if (this.mark) {
+      editor.setSelection(this.mark, editor.getCursor())
+      return null
+    } else {
+      return editor.getCursor()
+    }
+  }
   async onload() {
     this.addCommand({
       id: 'kill-line',
@@ -40,11 +48,7 @@ export default class KillAndYankPlugin extends Plugin {
       hotkeys: [{ modifiers: ['Ctrl'], key: 'w' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
         if (this.isComposing(view)) return
-
-        if (this.mark) {
-          editor.setSelection(this.mark, editor.getCursor())
-          this.mark = null
-        }
+        this.isMark(editor);
         this.killRing = editor.getSelection()
         editor.replaceSelection('')
       },
@@ -66,12 +70,7 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Set mark (Toggle the start position of the selection)',
       hotkeys: [{ modifiers: ['Ctrl'], key: ' ' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        if (this.mark) {
-          editor.setSelection(this.mark, editor.getCursor())
-          this.mark = null
-          return
-        }
-        this.mark = editor.getCursor()
+        this.mark = this.isMark(editor);
       },
     })
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ export default class KillAndYankPlugin extends Plugin {
 
   private isComposing(view: MarkdownView): boolean {
     // @ts-expect-error
-    const editorView = view.editor.cm as EditorView        
+    const editorView = view.editor.cm as EditorView
     // console.log(`composing = ${editorView.composing}`);
     return editorView.composing
   }
@@ -16,9 +16,9 @@ export default class KillAndYankPlugin extends Plugin {
   private isMark(editor: Editor): boolean {
     if (this.mark) {
       editor.setSelection(this.mark, editor.getCursor())
-      return true;
+      return true
     }
-    return false;
+    return false
   }
 
   async onload() {
@@ -35,7 +35,8 @@ export default class KillAndYankPlugin extends Plugin {
         const textToBeRetained = line.slice(0, position.ch)
         const textToBeCut = line.slice(position.ch)
 
-        this.killRing = textToBeCut
+        // this.killRing = textToBeCut
+        navigator.clipboard.writeText(textToBeCut)
 
         editor.setLine(position.line, textToBeRetained)
         editor.setCursor(position, position.ch)
@@ -48,8 +49,9 @@ export default class KillAndYankPlugin extends Plugin {
       hotkeys: [{ modifiers: ['Ctrl'], key: 'w' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
         if (this.isComposing(view)) return
-        this.mark = this.isMark(editor) ? null : null;
-        this.killRing = editor.getSelection()
+        this.mark = this.isMark(editor) ? null : null
+        // this.killRing = editor.getSelection()
+        navigator.clipboard.writeText(editor.getSelection())
         editor.replaceSelection('')
       },
     })
@@ -61,7 +63,10 @@ export default class KillAndYankPlugin extends Plugin {
       editorCallback: (editor: Editor, view: MarkdownView) => {
         if (this.isComposing(view)) return
 
-        editor.replaceSelection(this.killRing)
+        navigator.clipboard.readText().then((text) => {
+          editor.replaceSelection(text)
+        })
+        // editor.replaceSelection(this.killRing)
       },
     })
 
@@ -70,7 +75,7 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Set mark (Toggle the start position of the selection)',
       hotkeys: [{ modifiers: ['Ctrl'], key: ' ' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        this.mark = this.isMark(editor) ? null : editor.getCursor();
+        this.mark = this.isMark(editor) ? null : editor.getCursor()
       },
     })
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,21 +6,21 @@ export default class KillAndYankPlugin extends Plugin {
   private killRing: string
   private mark: EditorPosition | null = null
 
-  private isComposing(view: MarkdownView) {
+  private isComposing(view: MarkdownView): boolean {
     // @ts-expect-error
     const editorView = view.editor.cm as EditorView        
     // console.log(`composing = ${editorView.composing}`);
     return editorView.composing
   }
 
-  private isMark(editor: Editor) {
+  private isMark(editor: Editor): boolean {
     if (this.mark) {
       editor.setSelection(this.mark, editor.getCursor())
-      return null
-    } else {
-      return editor.getCursor()
+      return true;
     }
+    return false;
   }
+
   async onload() {
     this.addCommand({
       id: 'kill-line',
@@ -48,8 +48,7 @@ export default class KillAndYankPlugin extends Plugin {
       hotkeys: [{ modifiers: ['Ctrl'], key: 'w' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
         if (this.isComposing(view)) return
-        this.isMark(editor);
-        this.mark = null;
+        this.mark = this.isMark(editor) ? null : null;
         this.killRing = editor.getSelection()
         editor.replaceSelection('')
       },
@@ -71,7 +70,7 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Set mark (Toggle the start position of the selection)',
       hotkeys: [{ modifiers: ['Ctrl'], key: ' ' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        this.mark = this.isMark(editor);
+        this.mark = this.isMark(editor) ? null : editor.getCursor();
       },
     })
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { Editor, EditorPosition, MarkdownView, Plugin } from 'obsidian'
 import { EditorView } from '@codemirror/view'
 
+// @ts-expect-error
+const editorView = view.editor.cm as EditorView
+
 export default class KillAndYankPlugin extends Plugin {
   private editor: Editor
   private killRing: string
@@ -12,9 +15,6 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Kill line (Cut from the cursor position to the end of the line)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'k' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        // @ts-expect-error
-        const editorView = view.editor.cm as EditorView
-
         if (!editorView.composing) {
           const position: EditorPosition = editor.getCursor()
           const line: string = editor.getLine(position.line)
@@ -35,8 +35,10 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Kill region (Cut the selection)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'w' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        this.killRing = editor.getSelection()
-        editor.replaceSelection('')
+        if (!editorView.composing) {        
+          this.killRing = editor.getSelection()
+          editor.replaceSelection('')
+        }
       },
     })
 
@@ -45,7 +47,9 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Yank (Paste)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'y' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        editor.replaceSelection(this.killRing)
+        if (!editorView.composing) {        
+          editor.replaceSelection(this.killRing)
+        }
       },
     })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,6 @@
 import { Editor, EditorPosition, MarkdownView, Plugin } from 'obsidian'
 import { EditorView } from '@codemirror/view'
 
-// @ts-expect-error
-const editorView = view.editor.cm as EditorView
-
 export default class KillAndYankPlugin extends Plugin {
   private editor: Editor
   private killRing: string
@@ -15,6 +12,9 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Kill line (Cut from the cursor position to the end of the line)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'k' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
+        // @ts-expect-error
+        const editorView = view.editor.cm as EditorView
+
         if (!editorView.composing) {
           const position: EditorPosition = editor.getCursor()
           const line: string = editor.getLine(position.line)
@@ -35,10 +35,12 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Kill region (Cut the selection)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'w' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        if (!editorView.composing) {        
-          this.killRing = editor.getSelection()
-          editor.replaceSelection('')
+        if (this.mark) {
+          editor.setSelection(this.mark, editor.getCursor())
+          this.mark = null
         }
+        this.killRing = editor.getSelection()
+        editor.replaceSelection('')
       },
     })
 
@@ -47,9 +49,7 @@ export default class KillAndYankPlugin extends Plugin {
       name: 'Yank (Paste)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'y' }],
       editorCallback: (editor: Editor, view: MarkdownView) => {
-        if (!editorView.composing) {        
-          editor.replaceSelection(this.killRing)
-        }
+        editor.replaceSelection(this.killRing)
       },
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,70 @@
 # yarn lockfile v1
 
 
+"@codemirror/autocomplete@^6.0.0":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz#938b25223bd21f97b2a6d85474643355f98b505b"
+  integrity sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.6.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.0.0":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.2.1.tgz#ab5e979ad1458bbe395bf69ac601f461ac73cf08"
+  integrity sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.2.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/language@^6.0.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.6.0.tgz#2204407174a38a68053715c19e28ad61f491779f"
+  integrity sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.1.1.tgz#b30741e714a43a11cb78feb2c220b4971ad175f3"
+  integrity sha512-e+M543x0NVHGayNHQzLP4XByJsvbu/ojY6+0VF2Y4Uu66Rt1nADuxNflZwECLf7gS009smIsptSUa6bUj/U/rw==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.0.0":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.2.3.tgz#fab933fef1b1de8ef40cda275c73d9ac7a1ff40f"
+  integrity sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.4", "@codemirror/state@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.2.0.tgz#a0fb08403ced8c2a68d1d0acee926bd20be922f2"
+  integrity sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==
+
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.6.0":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.9.1.tgz#2ce4c528974b6172a5a4a738b7b0a0f04a4c1140"
+  integrity sha512-bzfSjJn9dAADVpabLKWKNmMG4ibyTV2e3eOGowjElNPTdTkSbi6ixPYHm2u0ADcETfKsi2/R84Rkmi91dH9yEg==
+  dependencies:
+    "@codemirror/state" "^6.1.4"
+    style-mod "^4.0.0"
+    w3c-keyname "^2.2.4"
+
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
@@ -35,6 +99,25 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@lezer/common@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.0.2.tgz#8fb9b86bdaa2ece57e7d59e5ffbcb37d71815087"
+  integrity sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng==
+
+"@lezer/highlight@^1.0.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.1.3.tgz#bf5a36c2ee227f526d74997ac91f7777e29bd25d"
+  integrity sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/lr@^1.0.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.3.3.tgz#0ac6c889f1235874f33c45a1b9785d7054f60708"
+  integrity sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==
+  dependencies:
+    "@lezer/common" "^1.0.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -246,6 +329,19 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+codemirror@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.1.tgz#62b91142d45904547ee3e0e0e4c1a79158035a29"
+  integrity sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -262,6 +358,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+crelt@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
+  integrity sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==
 
 cross-spawn@^7.0.2:
   version "7.0.3"
@@ -983,6 +1084,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+style-mod@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
+  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -1042,6 +1148,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"
+  integrity sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Added the following two features:
While typing in any language using an IME, kill-and-yank functionalities are disabled.
Use a clipboard.

Visit https://zenn.dev/sho7650/articles/6971eca7d2e619 for more information.