### PR TITLE
chore: リリース周りの技術的負債を解消

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      PLUGIN_NAME: kill-and-yank
+    permissions:
+      # gh release create でリリースを作成するために必要です
+      contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # pnpm/setup は pnpm と Node の用意から pnpm install までを行うため、actions/setup-node は不要です
       # pnpm のバージョンは package.json の packageManager フィールドから解決されます
@@ -20,55 +21,17 @@ jobs:
           cache: true
 
       - name: Build
-        id: build
+        run: pnpm build
+
+      # gh はランナーにプリインストールされているため、別途インストールする必要はありません
+      # --generate-notes は従来 GitHub 上で生成していたリリースノートを自動で付けます
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pnpm build
-          mkdir ${{ env.PLUGIN_NAME }}
-          cp main.js manifest.json ${{ env.PLUGIN_NAME }}
-          zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
-          ls
+          tag="${GITHUB_REF#refs/tags/}"
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ github.ref }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload zip file
-        id: upload-zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.PLUGIN_NAME }}.zip
-          asset_name: ${{ env.PLUGIN_NAME }}-${{ steps.build.outputs.tag_name }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload main.js
-        id: upload-main
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./main.js
-          asset_name: main.js
-          asset_content_type: text/javascript
-
-      - name: Upload manifest.json
-        id: upload-manifest
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./manifest.json
-          asset_name: manifest.json
-          asset_content_type: application/json
+          gh release create "$tag" \
+            --title "$tag" \
+            --generate-notes \
+            main.js manifest.json

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ git push --tags
 
 ### Manually installing this plugin
 
-Copy over `main.js`, `styles.css`, `manifest.json` to your vault `VaultFolder/.obsidian/plugins/kill-and-yank/`.
+Copy over `main.js` and `manifest.json` to your vault `VaultFolder/.obsidian/plugins/kill-and-yank/`.

--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ pnpm build
 
 ### Release
 
-Bump the version with an explicit version number:
+Bump the version:
 
 ```shell
-pnpm version 1.3.0 --tag-version-prefix ""
+pnpm version patch --tag-version-prefix ""
 ```
+
+`patch`, `minor`, `major` and an explicit version number such as `1.3.0` are all accepted.
 
 This runs `version-bump.mjs` through the `version` lifecycle script, which writes the new version into `manifest.json` and `versions.json`, then creates a commit and a tag.
 
 `--tag-version-prefix ""` is required. pnpm prefixes tags with `v` by default, while the release workflow and the Obsidian community plugin flow expect the tag to match the version in `manifest.json` exactly (for example `1.2.0`).
-
-Pass an explicit version rather than `patch` or `minor`, because `version` in `package.json` is not kept in sync with `manifest.json`.
 
 Then push the commit and the tag to trigger the release workflow:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kill-and-yank",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Obsidian plugin to enable kill and yank (like Emacs) in the editor",
   "main": "main.js",
   "scripts": {

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,0 @@
-/*
-
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
-
-If your plugin does not need CSS, delete this file.
-
-*/


### PR DESCRIPTION
# 概要

次回リリース時に失敗またはハマる箇所を解消します。

`release.yml` が依存している `actions/create-release` と `actions/upload-release-asset` は、いずれも 2021年3月にアーカイブされておりメンテナンスされていません。置き換えにあたって調査したところ、リリース周りに他の問題も見つかったため、同じ範囲でまとめて修正します。

PR #16 の「別途対応したい点」のうち、リリースに関わる項目を対象としています。

# 主な変更点

## リリースワークフローを gh release create へ移行

Obsidian 公式サンプルプラグインの `release.yml` に合わせて、`gh release create` へ置き換えました。`gh` は GitHub ホストランナーにプリインストールされているため、追加のインストールは不要です。

- アーカイブ済みのサードパーティ action への依存が 2つなくなりました
- PAT である `secrets.RELEASE_TOKEN` が不要になり、`secrets.GITHUB_TOKEN` と `permissions` の `contents: write` で完結します
- 従来 GitHub 上で生成していたリリースノートを `--generate-notes` で自動生成します。公開済みの 1.2.0 と同じ形式です
- `actions/checkout` を v3 から v7.0.1 へ更新し、同一ファイル内の `pnpm/setup` に合わせてコミット SHA で固定しました

`secrets.RELEASE_TOKEN` はリポジトリ内の他の箇所から参照されていないため、GitHub の Secrets から削除できます。

## zip アセットの廃止

Obsidian のプラグイン配布は `main.js` と `manifest.json` の個別ファイルで行われ、公式サンプルも zip を作成していません。

加えて、アセット名を組み立てている `steps.build.outputs.tag_name` はどのステップからも設定されておらず、公開済みの 1.2.0 では `kill-and-yank-.zip` という壊れた名前のまま配布されていました。

## 中身が空の styles.css を削除

サンプルプラグイン由来のコメントが残っているだけで、スタイルの定義を一切含んでいませんでした。公式サンプルも「If your plugin does not need CSS, delete this file.」と案内しています。

リリースアセットにも含まれていなかったため、既存の利用者への影響はありません。README の手動インストール手順からも記述を外しました。

## package.json の version を manifest.json に合わせる

`package.json` は 1.0.0 のまま放置されており、実際にリリースされている `manifest.json` の 1.2.0 とずれていました。

`pnpm version` は `package.json` の version を基準にバージョンを上げるため、ずれたままでは `patch` や `minor` が使えませんでした。同期したことでこれらが使えるようになったため、明示的なバージョン番号を渡すよう案内していた README を修正しています。

# 検証

変更したファイルに対して以下を実行し、すべて成功することを確認しました。

- `pnpm exec prettier --check`
- `pnpm lint`
- `pnpm build`

`styles.css` の削除については、`git grep` でリポジトリ全体を対象に参照が残っていないことを確認したうえで、ビルドが通ることを確認しました。

バージョン更新については、隔離したディレクトリに修正後の `package.json` を持ち込んで `pnpm version patch --tag-version-prefix ""` を実行し、次を確認しました。

- `package.json`、`manifest.json`、`versions.json` がいずれも 1.2.1 へ更新される
- 作成されるタグが `v` プレフィックスなしの `1.2.1` になる
- 3つのファイルがバージョン更新のコミットに含まれる

# 未検証の点

- `release.yml` はタグ push 時のみ実行されるため、本 PR では検証されません。次回リリース時が初回の実行になります

# 別途対応したい点

本 PR のスコープ外のため、指摘に留めます。

- `version-bump.mjs` は `manifest.json` をタブインデントで書き出しますが、現在の `manifest.json` は 2スペースインデントです。次回のバージョン更新時に全行が差分として現れます
- `main.yml` の `::set-output` は非推奨で、実行時に警告が出ます
- `main.yml` の `NEXT_PUBLIC_SUPABASE_API_URL` と `NEXT_PUBLIC_SUPABASE_ANON_KEY` は本リポジトリのどこからも参照されていません
- 依存パッケージ自体が古い状態です（esbuild 0.14、TypeScript 4.7、ESLint 8、Prettier 2）
- `renovate.json` の `config:base` は `config:recommended` へ改名されています
- ローカルで `pnpm format:check` を実行すると、Claude Code が生成する `.claude/settings.local.json` が対象に含まれて失敗します。`.prettierignore` への追加を検討する余地があります
