### PR TITLE
chore: CI とツール設定の軽微な負債を解消

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_SUPABASE_API_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_API_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # コミットメッセージは複数行になりうるため、デリミタで囲む形式で渡します
       - name: '[Pull Request] Get commit message'
         id: pr_get_commit_message
-        run: echo ::set-output name=pr_commit_message::$(git log --format=%B -n 1 HEAD^2)
+        run: |
+          {
+            echo 'pr_commit_message<<EOF'
+            git log --format=%B -n 1 HEAD^2
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ README.md
 main.js
 
 pnpm-lock.yaml
+
+.claude/

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "schedule": ["after 5am and before 8am on saturday"],
   "packageRules": [
     {

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -6,9 +6,10 @@ const targetVersion = process.env.npm_package_version
 let manifest = JSON.parse(readFileSync('manifest.json', 'utf8'))
 const { minAppVersion } = manifest
 manifest.version = targetVersion
-writeFileSync('manifest.json', JSON.stringify(manifest, null, '\t'))
+// Both files are checked by `prettier --check`, so match its 2-space indent and trailing newline
+writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n')
 
 // update versions.json with target version and minAppVersion from manifest.json
 let versions = JSON.parse(readFileSync('versions.json', 'utf8'))
 versions[targetVersion] = minAppVersion
-writeFileSync('versions.json', JSON.stringify(versions, null, '\t'))
+writeFileSync('versions.json', JSON.stringify(versions, null, 2) + '\n')


### PR DESCRIPTION
# 概要

PR #17 の「別途対応したい点」のうち、軽微な項目をまとめて解消します。

依存パッケージの更新は規模も影響範囲も異なるため、本 PR には含めていません。

# 主な変更点

## version-bump.mjs の出力を Prettier のスタイルに合わせる

本 PR で最も影響が大きい変更です。

`version-bump.mjs` は `manifest.json` と `versions.json` をタブインデントかつ末尾の改行なしで書き出していましたが、これらは `prettier --check` の対象です。そのため次回バージョンを上げると、生成されたファイルがフォーマットチェックに落ち、以降の CI が失敗する状態でした。

`JSON.stringify` の出力を 2スペースインデントと末尾の改行に変更し、Prettier の期待する形に揃えています。

なお PR #17 の本文では「`manifest.json` を `version-bump.mjs` に合わせてタブインデントへ揃える」と指摘していましたが、これは誤りです。タブへ揃えるとその時点で `pnpm format:check` が失敗します。正しい対処は逆方向であり、本 PR では `version-bump.mjs` 側を修正しました。

## 非推奨の set-output を GITHUB_OUTPUT へ置き換え

`set-output` は非推奨で、実行時に警告が出ていました。

置き換えにあたってデリミタで囲む形式を採用しています。`GITHUB_OUTPUT` で複数行の値を渡すにはデリミタが必要であり、また従来のコマンド置換ではコミットメッセージが複数行のときに Slack 通知へ正しく渡せていませんでした。

## CI から参照されていない Supabase の環境変数を削除

`NEXT_PUBLIC_SUPABASE_API_URL` と `NEXT_PUBLIC_SUPABASE_ANON_KEY` は、本リポジトリのどこからも参照されていませんでした。Obsidian プラグインである本リポジトリと Supabase に関連はなく、他プロジェクトの設定が持ち込まれたものと思われます。

## Renovate のプリセットを config:recommended へ変更

`config:base` は `config:recommended` へ改名されており、公式ドキュメントのプリセット一覧からも記載がなくなっています。

## Prettier のチェック対象から .claude/ を除外

Claude Code が生成する `.claude/settings.local.json` がチェック対象に含まれており、手元で `pnpm format:check` が失敗していました。同ファイルはグローバルの gitignore で除外されておりリポジトリには含まれないため、CI では顕在化せず手元でのみ失敗する状態でした。

# 検証

リポジトリ全体に対して以下を実行し、すべて成功することを確認しました。

- `pnpm format:check`
- `pnpm lint`
- `pnpm build`

`version-bump.mjs` の修正については、隔離したディレクトリに修正後のファイルを持ち込んで `pnpm version patch --tag-version-prefix ""` を実行し、次を確認しました。

- 生成された `manifest.json` と `versions.json` が 2スペースインデントかつ末尾の改行ありになる
- 生成物が `prettier --check` を通る
- 既存ファイルとの差分が、`manifest.json` は version の 1行、`versions.json` は追加された 1行のみになる
- バージョン更新とタグの作成はこれまでどおり動作する

本リポジトリにはテストランナーがなく、その導入は本 PR のスコープを大きく超えるため、テストの追加ではなく上記の実行検証で確認しています。

# 未検証の点

- `main.yml` の `set-output` 置き換えは、本 PR の CI 実行で検証されます
- Renovate のプリセット変更は、次回 Renovate が実行されるまで検証されません

# 別途対応したい点

- 依存パッケージ自体が古い状態です（esbuild 0.14、TypeScript 4.7、ESLint 8、Prettier 2）
