### PR TITLE
chore: Renovate の自動更新で壊れる組み合わせを防ぐ

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
           runtime: node@24
           cache: true
 
+      # install や build は peer dependency の不整合を検出しないため、個別に確認します
+      - name: Check peer dependencies
+        run: pnpm peers check
+
       - name: Check format
         run: pnpm format:check
 

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,16 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin"],
       "automerge": true
+    },
+    {
+      "description": "obsidian が peerDependencies で厳密なバージョンを指定するため、obsidian の更新に合わせて手動で追従します",
+      "matchPackageNames": ["@codemirror/view"],
+      "enabled": false
+    },
+    {
+      "description": "typescript-eslint 8 の対応範囲が 6.1.0 未満のため、7.x へは上げません",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<6.1.0"
     }
   ]
 }


### PR DESCRIPTION
# 概要

Renovate を本リポジトリで有効化したことに伴い、自動マージが壊れる更新を取り込まないようにします。

有効化の経緯は後述しますが、稼働を始めた Renovate が早速 4件の更新を検出しており（#21）、そのうち 1件はそのまま取り込むと動かなくなる組み合わせでした。

# 主な変更点

## Renovate が壊れる更新を出さないよう制約を追加

`@codemirror/view` を Renovate の対象から外しました。obsidian が peerDependencies で厳密なバージョンを指定しており、6.43.8 へ上がると obsidian 1.13.1 の要求と食い違います。

この更新は minor に該当するため、本リポジトリの `automerge: true` 設定では **人の目を通らずに取り込まれます**。obsidian の更新に合わせて手動で追従する運用とし、その旨を `description` に残しました。

`typescript` は typescript-eslint 8 の対応範囲が `>=4.8.4 <6.1.0` であるため、`allowedVersions` で 7.x を抑止しました。major なので自動マージはされませんが、Dependency Dashboard から手動で PR を作成できてしまう状態でした。

## CI に peer dependency の検証を追加

`pnpm peers check` のステップを追加しました。

# 検証

`@codemirror/view` を Renovate が上げようとしている 6.43.8 にした状態で、各コマンドの終了コードを確認しました。

- `pnpm install --frozen-lockfile` -> 0（素通り）
- `pnpm build` -> 0（素通り）
- `pnpm peers check` -> 1（検出）

検出時の出力は次のとおりです。

```
✕ unmet peer @codemirror/view
  Installed: 6.43.8
  Wanted:
    6.38.6:
      obsidian@1.13.1
```

つまり従来の CI では、peer 依存を壊す更新がそのまま通過していました。確認後、`package.json` と `pnpm-lock.yaml` は元に戻しています。

本 PR の状態では `pnpm peers check` / `pnpm format:check` / `pnpm lint` / `pnpm build` がいずれも成功することを確認しました。

# Renovate 有効化についての補足

PR #20 の本文で「Renovate の App がインストールされていないと思われます」と書きましたが、**これは誤りでした**。

実際には App は 4年前から `inouetakuya` アカウントにインストールされており、リポジトリアクセスが「Only select repositories」で 8リポジトリに限定されていて、本リポジトリがその中に含まれていなかったというのが正しい状況です。

本リポジトリを選択リストへ追加したことで Renovate が稼働を開始し、Dependency Dashboard（#21）が作成されています。

# 補足

`@codemirror/view` を Renovate 対象外にしたため、obsidian を更新する際は `@codemirror/view` の追従も忘れずに行う必要があります。`pnpm peers check` が CI に入ったことで、追従を忘れた場合は CI が落ちて気づけます。
