### PR TITLE
chore: Renovate のスケジュール限定を外し他リポジトリの運用に揃える

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "schedule": ["after 5am and before 8am on saturday"],
+  "extends": ["config:best-practices"],
+  "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "14 days",
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 0,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "matchUpdateTypes": ["patch", "pin"],
       "automerge": true
     },
     {
@@ -13,9 +20,10 @@
       "enabled": false
     },
     {
-      "description": "typescript-eslint 8 の対応範囲が 6.1.0 未満のため、7.x へは上げません",
+      "description": "TypeScript 7 は typescript-eslint 8 の対応範囲（>=4.8.4 <6.1.0）から外れるため一時停止します。typescript-eslint が TypeScript 7 へ対応したら解禁し、本ルールを削除します",
       "matchPackageNames": ["typescript"],
-      "allowedVersions": "<6.1.0"
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
# 概要

Renovate の実行を土曜の朝に限定していたスケジュールを外し、あわせて設定を potts と dadian の運用に揃えます。

スケジュールを限定していた当時と働き方が変わり、時間帯を絞る必要がなくなったためです。potts と dadian はいずれも `schedule` を設定していません。

# 主な変更点

## スケジュールの削除

`"schedule": ["after 5am and before 8am on saturday"]` を削除しました。これにより Renovate は時間帯に関係なく実行されます。

## extends を config:best-practices へ

potts に合わせました。`config:best-practices` は `config:recommended` を含んだうえで、次のプリセットを追加します。

- `helpers:pinGitHubActionDigests` - GitHub Actions を SHA でピン
- `:pinDevDependencies` - devDependencies をバージョン固定
- `:configMigration` - 設定が古くなったら移行 PR を作成
- `abandonments:recommended` - 1年以上リリースのないパッケージを検出
- `security:minimumReleaseAgeNpm` - npm パッケージの3日待機
- `:maintainLockFilesWeekly` - 週次の lockfile 保守
- `docker:pinDigests` - Docker digest のピン（本リポジトリでは該当なし）

いずれも本リポジトリでこれまで手作業で進めてきた内容と方向性が一致します。特に `:configMigration` は、`config:base` が `config:recommended` へ改名されていたことに気づけず PR #18 で手作業で直した経緯があり、今後は自動で移行 PR が届きます。

## dadian の個別設定を取り込み

- `timezone: "Asia/Tokyo"`
- `minimumReleaseAge: "14 days"`
- `prConcurrentLimit: 2` / `prHourlyLimit: 0`
- `lockFileMaintenance` の有効化と automerge

`minimumReleaseAge` は `security:minimumReleaseAgeNpm` の3日を上書きします。PR #20 で ESLint 10.8.1 が pnpm のサプライチェーン保護に弾かれた件があり、Renovate 側も同じだけ待つようにすることで歩調が揃います。

## 自動マージの範囲を patch / pin に

minor を自動マージの対象から外しました。dadian に合わせています。

PR #22 で対処したとおり、`@codemirror/view` の minor 更新が peer 依存を壊す寸前でした。minor は人の目を通す価値があると判断しています。

## typescript の抑止方法を変更

`allowedVersions: "<6.1.0"` から、dadian と同じ `matchUpdateTypes: ["major"]` と `enabled: false` の組み合わせへ変更しました。解禁条件を `description` に明記でき、運用しやすくなります。

# 本リポジトリ固有の設定

次の 2つは変更せず残しています。

- `@codemirror/view` の無効化（obsidian の peerDependencies が厳密指定のため）
- typescript の major 抑止（typescript-eslint 8 の対応範囲外のため）

# 検証

Renovate 公式のバリデーターで検証し、成功することを確認しました。

```
$ pnpm dlx --package renovate -- renovate-config-validator --no-global renovate.json
 INFO: Validating renovate.json as repo config
 INFO: Config validated successfully against 1 file(s)
```

`pnpm format:check` も通過しています。

# マージ後に見込まれる PR

`config:best-practices` の追加により、次のような PR が届くと見込まれます。

- `main.yml` の `actions/checkout@v3` と `rtCamp/action-slack-notify@v2` を SHA へピン
- `package.json` の caret 指定（`@eslint/js` や `@types/node` など）をバージョン固定へ

いずれも望ましい方向の変更です。
