### PR TITLE
fix: minimumReleaseAge で Renovate の更新が永久に保留される問題を解消

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,19 @@
   },
   "packageRules": [
     {
+      "description": "リリース日時を持たない更新種別を minimumReleaseAge の対象外にします。これらに適用すると更新が永久に保留されるため、security:minimumReleaseAgeNpm も同じ除外を持ちますが、本設定のトップレベルの minimumReleaseAge がそれを打ち消すため明示します",
+      "matchUpdateTypes": [
+        "lockFileMaintenance",
+        "replacement",
+        "pin",
+        "pinDigest",
+        "bump",
+        "lockfileUpdate",
+        "rollback"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "matchUpdateTypes": ["patch", "pin"],
       "automerge": true
     },


### PR DESCRIPTION
# 概要

Renovate の PR が `renovate/stability-days` の pending で滞留する問題を解消します。

#23 でトップレベルに `minimumReleaseAge: "14 days"` を追加した際、`config:best-practices` が持っていた除外設定を打ち消してしまったことが原因です。

# 原因

`config:best-practices` に含まれる `security:minimumReleaseAgeNpm` は、リリース日時を持たない更新種別を `minimumReleaseAge` の対象外にする packageRules を持っています。

Renovate のプリセット定義には、その理由がコメントで明記されています。

> Certain update types don't currently support `releaseTimestamp`s, so applying `minimumReleaseAge` to them results in updates that will never come.

トップレベルに `minimumReleaseAge` を書くとこの除外が打ち消され、まさに「更新が永久に来ない」状態になります。

実際に次の 2つの PR が滞留していました。

- #26 lock file maintenance
- #24 pin dependencies

いずれも CI（build）は pass しており、内容にも問題はありません。`renovate/stability-days` だけが pending のままです。

一方 #25（actions/checkout の v7 更新）は正常にマージされています。`security:minimumReleaseAgeNpm` が npm datasource 限定であるのに対し、トップレベル指定は datasource を問わず適用されるため、影響範囲が広がっていました。

# 主な変更点

プリセットと同じ除外を packageRules で明示しました。

対象の更新種別は Renovate のプリセット定義に合わせています。

- `lockFileMaintenance`
- `replacement`
- `pin`
- `bump`
- `lockfileUpdate`
- `rollback`

加えて `pinDigest` も同じ扱いにしました。プリセットには含まれていませんが、既存バージョンを SHA へ固定する操作であり新しいものを取り込まないためです。#24 には npm の pin と GitHub Actions の pinDigest が混在しており、両方を除外しないと解消しません。

通常の更新に対する 14日待機は維持されます。

# 検証

Renovate 公式のバリデーターで検証しました。

```
$ pnpm dlx --package renovate -- renovate-config-validator --no-global renovate.json
 INFO: Validating renovate.json as repo config
 INFO: Config validated successfully against 1 file(s)
```

`pnpm format:check` も通過しています。

# マージ後に期待される挙動

Renovate が #26 と #24 を再評価し、`renovate/stability-days` が pass して automerge されると見込んでいます。そうならない場合は、除外の指定方法を再検討します。

# 関連

同じ組み合わせは dadian でも起こりえます。inouetakuya/dadian#3302 で `config:best-practices` への変更を提案していますが、dadian も `minimumReleaseAge: "14 days"` を持っているため、本 PR と同じ除外が必要です。この知見は当該 Issue へ追記します。
