### PR TITLE
chore: Renovate の待機期間の乖離を解消し automerge の抜けを塞ぐ

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "timezone": "Asia/Tokyo",
-  "minimumReleaseAge": "14 days",
   "prConcurrentLimit": 2,
   "prHourlyLimit": 0,
   "lockFileMaintenance": {
@@ -11,21 +10,18 @@
   },
   "packageRules": [
     {
-      "description": "リリース日時を持たない更新種別を minimumReleaseAge の対象外にします。これらに適用すると更新が永久に保留されるため、security:minimumReleaseAgeNpm も同じ除外を持ちますが、本設定のトップレベルの minimumReleaseAge がそれを打ち消すため明示します",
-      "matchUpdateTypes": [
-        "lockFileMaintenance",
-        "replacement",
-        "pin",
-        "pinDigest",
-        "bump",
-        "lockfileUpdate",
-        "rollback"
-      ],
-      "minimumReleaseAge": null
-    },
-    {
       "matchUpdateTypes": ["patch", "pin"],
       "automerge": true
+    },
+    {
+      "description": "Renovate では pin と pinDigest が別の updateType のため、pin だけでは digest のピン留めが automerge の対象になりません。pinDigest は現在参照している実体を記録するだけで、ピン留めしなければ実行されるものと同じであるため automerge して差し支えありません。実体の変化に追随する digest は意図的に対象外とします",
+      "matchUpdateTypes": ["pinDigest"],
+      "automerge": true
+    },
+    {
+      "description": "Renovate の既定の並び順は lockFileMaintenance を最後尾に置くため、prConcurrentLimit の枠を他の更新に奪われ続けて PR が作られなくなります。prPriority は並び順より先に評価されるため、正の値を与えて先頭へ引き上げます",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "prPriority": 10
     },
     {
       "description": "obsidian が peerDependencies で厳密なバージョンを指定するため、obsidian の更新に合わせて手動で追従します",


### PR DESCRIPTION
# 概要

Renovate の待機期間の設定が記述と実態で乖離していた問題を解消し、あわせて automerge が働かないケースへ dadian の知見を取り込みます。

きっかけは #28 が automerge されなかったことです。調査の過程で、待機期間の設定が意図どおり効いていないことも判明しました。

# 主な変更点

## トップレベルの minimumReleaseAge を削除

`config:best-practices` が持つ 3日待機に任せます。potts と同じ形です。

`"14 days"` と書いていましたが、実際には 3日で動いていました。`config:best-practices` に含まれる `security:minimumReleaseAgeNpm` が packageRules で 3日を設定しており、**packageRules はトップレベル設定より後に適用される**ためです。

実例として #28（esbuild 0.28.2）は、リリースから 5日の時点で `renovate/stability-days` が pass しています。14日が効いていれば pending のままだったはずです。

この優先順位については dadian の設定にも同じ記述があり、あちらは packageRules 側で 14日を再指定して維持しています。本リポジトリは devDependencies のみで配布物にも含まれないため、プリセットの 3日をそのまま受け入れる形にしました。

あわせて、トップレベルの指定を打ち消すために #27 で置いた除外ルールも削除しました。トップレベルの指定がなくなれば、プリセット自身が持つ除外がそのまま働くため不要になります。

## pinDigest の automerge を追加

Renovate では `pin` と `pinDigest` が別の updateType のため、`matchUpdateTypes: ["pin"]` だけでは digest のピン留めが automerge の対象になりません。

**#24 が automerge されなかったのはこれが一因です。** あの PR には npm の pin と GitHub Actions の pinDigest が混在していました。

dadian でも PR が 3日間滞留した実績があり、同じ対処が入っています。実体の変化に追随する `digest` は意図的に対象外とし、`pinDigest` のみを automerge します。

## lockFileMaintenance に prPriority を付与

Renovate の既定の並び順は lockFileMaintenance を最後尾に置くため、`prConcurrentLimit` の枠を他の更新に奪われ続けて PR が作られなくなります。本リポジトリは `prConcurrentLimit: 2` のため該当します。

`prPriority: 10` を与えて先頭へ引き上げます。これも dadian の運用に倣ったものです。

# リポジトリ設定の変更（本 PR の範囲外）

`#28` が automerge されなかった直接の原因は、リポジトリの `allow_auto_merge` が `false` だったことです。

Renovate の `platformAutomerge`（既定で有効）は GitHub の auto-merge 機能を使いますが、無効な場合は Renovate 自身がマージするため、次回実行まで数時間待つことになります。#28 は CI 完了から 8分後に手動マージされており、Renovate の順番が回る前でした。

本 PR とは別に、`allow_auto_merge` を `true` へ変更済みです。dadian も同じ設定で、ブランチ保護は設けずに運用しています。

# 検証

Renovate 公式のバリデーターで検証しました。

```
$ pnpm dlx --package renovate -- renovate-config-validator --no-global renovate.json
 INFO: Validating renovate.json as repo config
 INFO: Config validated successfully against 1 file(s)
```

`pnpm format:check` も通過しています。

# マージ後に確認したいこと

- 次の Renovate PR が CI 完了後すぐに automerge されるか（`allow_auto_merge` の効果）
- `pinDigest` を含む PR が automerge されるか
- 待機期間が 3日で運用されるか
