### PR TITLE
chore: メジャー以外の更新を automerge の対象にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,8 @@
   },
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "pin"],
-      "automerge": true
-    },
-    {
-      "description": "Renovate では pin と pinDigest が別の updateType のため、pin だけでは digest のピン留めが automerge の対象になりません。pinDigest は現在参照している実体を記録するだけで、ピン留めしなければ実行されるものと同じであるため automerge して差し支えありません。実体の変化に追随する digest は意図的に対象外とします",
-      "matchUpdateTypes": ["pinDigest"],
+      "description": "メジャー以外は CI の通過をもって自動マージします。pin と pinDigest、digest は minor / patch とは別の updateType として扱われるため、個別に列挙しないと対象になりません",
+      "matchUpdateTypes": ["minor", "patch", "pin", "pinDigest", "digest"],
       "automerge": true
     },
     {


### PR DESCRIPTION
# 概要

automerge の対象を「メジャー以外のすべて」へ広げます。

#33（typescript-eslint 8.66.0 -> 8.67.0）が automerge されなかったことがきっかけです。これは minor 更新であり、これまでの設定では対象外でした。

# 主な変更点

`matchUpdateTypes` に `minor` と `digest` を追加し、updateType ごとに分かれていたルールを 1つへ統合しました。

対象は `minor` / `patch` / `pin` / `pinDigest` / `digest` です。`lockFileMaintenance` は `lockFileMaintenance` オブジェクト側で automerge を有効にしているため、そのままです。

`pin` と `pinDigest`、`digest` は `minor` / `patch` とは別の updateType として扱われるため、個別に列挙しないと対象になりません。実際 #24 は SHA ピンを含んでいたために automerge されませんでした。

# minor を対象に戻す理由

#22 で minor を automerge から外しましたが、その判断の前提が変わっています。

当時の理由は、`@codemirror/view` の minor 更新が obsidian の peerDependencies を壊す寸前だったことでした。しかし同じ #22 で次の 2つを入れています。

- `@codemirror/view` を Renovate の対象外にした
- CI に `pnpm peers check` を追加した

peer 依存を壊す更新は CI で落ちるようになったため、minor を人の目に通す必要がなくなりました。

# esbuild と digest の扱い

いずれも例外を設けず、他と同じく automerge します。

esbuild は `0.x` のため minor に破壊的変更が含まれうるうえ、バンドル結果を直接左右します。ただし CI で型チェックとビルドの通過は確認されるため、まずは例外なしで運用し、問題が起きてから対処します。

`digest` は同じタグのまま実体が変わったことを意味するため慎重に扱う考え方もありますが（dadian は意図的に対象外としています）、本リポジトリでは「メジャー以外はすべて」を優先します。

# 検証

Renovate 公式のバリデーターで検証しました。

```
$ pnpm dlx --package renovate -- renovate-config-validator --no-global renovate.json
 INFO: Validating renovate.json as repo config
 INFO: Config validated successfully against 1 file(s)
```

`pnpm format:check` も通過しています。

# 補足: GitHub の auto-merge が効いていることを確認しました

#31 で `allow_auto_merge` を有効にした効果を、判別できていませんでした。その後 #32 が **作成と同じ分にマージ**されており、CI 完了直後に GitHub がマージしていることが確認できました。ブランチ保護への必須チェック追加は不要です。
