### PR TITLE
fix: editorCallback が MarkdownFileInfo を受け取る場合に対応する

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,12 @@
-import { Editor, EditorPosition, MarkdownView, Plugin } from 'obsidian'
+import { Editor, EditorPosition, Plugin } from 'obsidian'
 import { EditorView } from '@codemirror/view'
 
 export default class KillAndYankPlugin extends Plugin {
   private mark: EditorPosition | null = null
 
-  private isComposing(view: MarkdownView): boolean {
+  private isComposing(editor: Editor): boolean {
     // @ts-expect-error TS2339: Property 'cm' does not exist on type 'Editor'
-    const editorView = view.editor.cm as EditorView
+    const editorView = editor.cm as EditorView
     return editorView.composing
   }
 
@@ -15,8 +15,8 @@ export default class KillAndYankPlugin extends Plugin {
       id: 'kill-line',
       name: 'Kill line (Cut from the cursor position to the end of the line)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'k' }],
-      editorCallback: (editor: Editor, view: MarkdownView) => {
-        if (this.isComposing(view)) return
+      editorCallback: (editor: Editor) => {
+        if (this.isComposing(editor)) return
 
         const position: EditorPosition = editor.getCursor()
         const line: string = editor.getLine(position.line)
@@ -35,8 +35,8 @@ export default class KillAndYankPlugin extends Plugin {
       id: 'kill-region',
       name: 'Kill region (Cut the selection)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'w' }],
-      editorCallback: (editor: Editor, view: MarkdownView) => {
-        if (this.isComposing(view)) return
+      editorCallback: (editor: Editor) => {
+        if (this.isComposing(editor)) return
 
         if (this.mark) {
           editor.setSelection(this.mark, editor.getCursor())
@@ -51,8 +51,8 @@ export default class KillAndYankPlugin extends Plugin {
       id: 'yank',
       name: 'Yank (Paste)',
       hotkeys: [{ modifiers: ['Ctrl'], key: 'y' }],
-      editorCallback: (editor: Editor, view: MarkdownView) => {
-        if (this.isComposing(view)) return
+      editorCallback: (editor: Editor) => {
+        if (this.isComposing(editor)) return
 
         navigator.clipboard.readText().then((text) => {
           editor.replaceSelection(text)
@@ -64,7 +64,7 @@ export default class KillAndYankPlugin extends Plugin {
       id: 'set-mark',
       name: 'Set mark (Toggle the start position of the selection)',
       hotkeys: [{ modifiers: ['Ctrl'], key: ' ' }],
-      editorCallback: (editor: Editor, view: MarkdownView) => {
+      editorCallback: (editor: Editor) => {
         if (this.mark) {
           editor.setSelection(this.mark, editor.getCursor())
           this.mark = null

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,6 @@
     "module": "ESNext",
     "target": "ES6",
     "allowJs": true,
-    // TypeScript 6 で strict が既定で有効になりましたが、有効にすると Obsidian の
-    // editorCallback で型エラーが出るため、従来の型チェックレベルを維持します
-    "strict": false,
     "noImplicitAny": true,
     "moduleResolution": "bundler",
     "importHelpers": true,


### PR DESCRIPTION
# 概要

コマンドの `editorCallback` が受け取る第2引数を `MarkdownView` 前提で扱っていた箇所を、第2引数に依存しない形へ変更しました。あわせて `tsconfig.json` の `"strict": false` を削除しました。

実行時の振る舞いは変わりません。型定義との不整合を解消し、`strict` を有効化することが目的です。

Closes #19

# 背景

Obsidian の型定義では `editorCallback` の第2引数は `MarkdownView | MarkdownFileInfo` です。

```ts
editorCallback?: (editor: Editor, ctx: MarkdownView | MarkdownFileInfo) => any;
```

`MarkdownFileInfo` の `editor` は optional であるため、`MarkdownView` 前提で `view.editor` へアクセスする実装は型定義と整合しません。TypeScript 6 で既定になった `strict` を有効にすると、`strictFunctionTypes` がこれを型エラーとして検出します。

```
src/main.ts(18,7): error TS2322: Type '(editor: Editor, view: MarkdownView) => void' is not assignable to type '(editor: Editor, ctx: MarkdownView | MarkdownFileInfo) => any'.
```

# 調査

方針を決めるにあたり、Obsidian 1.13.7 のバンドルコード（`obsidian-1.13.7.asar` 内の `app.js`）を確認しました。以下の引用は最小化された変数名のまま、整形だけを行っています。

## editorCallback の第1引数は ctx.editor そのもの

コマンドの登録時に `checkCallback` が組み立てられ、その中で `editorCallback` が呼ばれます。

```js
e.checkCallback = function (n) {
  var i = t.app.workspace.activeEditor // i = ctx
  if (!i) return null
  if (e.allowPreview || 'preview' !== i.getMode()) {
    var r = i.editor, // r = ctx.editor
      o = i // o = ctx
    // ...
    return e.editorCheckCallback
      ? e.editorCheckCallback(n, r, o)
      : e.editorCallback
        ? (n || e.editorCallback(r, o), !0)
        : void 0
  }
}
```

第1引数として渡されるのは `ctx.editor` そのものです。従来アクセスしていた `view.editor` と同一の参照であるため、参照元を第1引数へ変えても等価です。

## MarkdownFileInfo が渡されるケースは実在する

`workspace.activeEditor` のアクセサは次のとおりです。

```js
get: function () {
  return this._activeEditor ?? this.getActiveViewOfType(MarkdownView)
},
set: function (e) {
  e instanceof MarkdownView || (this._activeEditor = e)
}
```

setter は `MarkdownView` でないものだけを保持します。実際に代入されるのは `markdown-embed` / `inline-embed` のクラスを持つ埋め込みエディタで、埋め込みノートの編集中はこれが `activeEditor` になります。

## editor が undefined になるケースは到達不能

埋め込みエディタ側の定義は次のとおりです。

```js
get editor() {
  return this.editMode?.editor
}
getMode() {
  return this.editMode ? 'source' : 'preview'
}
```

`editor` が `undefined` になるのは `editMode` がないときですが、そのとき `getMode()` は `'preview'` を返します。前掲のディスパッチャは `allowPreview || 'preview' !== i.getMode()` で弾くため、`allowPreview` を指定していない本プラグインのコマンドでは、その状態でコールバックが呼ばれることはありません。

# 主な変更点

## 第2引数に依存しない形へ変更

`isComposing` が必要とするのは CodeMirror の `EditorView` だけであり、これは第1引数の `editor` から取得できます。第1引数の `editor` は型定義上も非 optional です。

そこで `isComposing` の引数を `Editor` に変更し、各 `editorCallback` は第2引数を受け取らない形にしました。第2引数が `MarkdownView` と `MarkdownFileInfo` のどちらで渡されるかに依存しなくなり、型ガードによる分岐が不要になります。

TypeScript では引数の少ない関数を代入できるため、`(editor: Editor) => void` は `(editor: Editor, ctx: MarkdownView | MarkdownFileInfo) => any` に代入可能です。

なお、各コマンドの後続処理（`editor.getCursor()` など）はいずれも第1引数の `editor` に対して行っています。IME の変換中かどうかの判定も同じ `editor` に対して行うほうが、操作対象が一貫します。

## tsconfig.json の "strict": false を削除

型エラーが解消されたため、`"strict": false` と、その理由を説明していたコメントを削除しました。

# 本 PR の効果

- 型定義との不整合が解消され、`strict` を有効にできます
- 実行時の振る舞いは変わりません。`editor` は `ctx.editor` と同一の参照であり、仮に `ctx.editor` が `undefined` であれば変更の前後いずれも同じく TypeError になります。バグ修正ではありません

# Issue の完了条件との突き合わせ

Issue の完了条件はチェックボックスで書かれていないため、Issue 本文は更新せず、突き合わせの結果をここに記載します。

- 「`MarkdownFileInfo` が渡されるケースが実際に存在するかを実機で確認する」-> 存在することを確認しました。確認手段は実機の操作ではなく、Obsidian のバンドルコードの読解です
- 「存在する場合、型ガードで分岐させ、そのときの振る舞いを決める」-> 分岐は不要と判断しました。第1引数が `ctx.editor` と同一の参照であり、`editor` が `undefined` の状態ではコールバック自体が呼ばれないためです
- 「存在しない場合も、型定義に合わせて引数を `MarkdownView | MarkdownFileInfo` で受けられるようにする」-> 前提は成立しませんが、第2引数を受け取らないことで、型定義と整合させるという意図は満たしています
- 「`tsconfig.json` の `"strict": false` を外し、型チェックが通ることを確認する」-> 満たしています

# 検証内容

- 変更前のコードでは `"strict": false` を外すと型エラーが 4件再現し、変更後は解消されることを確認しました
- 配布済みの `1.2.0` の `main.js` と本ブランチのビルド成果物を比較し、差分が本 PR の変更箇所と esbuild の整形差だけであることを確認しました
- `pnpm build`（`tsc --noEmit` と esbuild によるビルド）が成功することを確認しました
- `pnpm lint` と `pnpm format:check` が成功することを確認しました

# テストについて

本リポジトリにはテスト基盤が存在せず、その導入はライブラリ選定を伴う独立した判断であり本 Issue のスコープを超えるため、今回は追加していません。本変更は実行時の振る舞いを変えない型レベルの修正であり、`tsc` の `strict` とビルドで検証しています。
